### PR TITLE
read RIDE2GO_TOKEN env var, tweak Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@ RUN \
 	# Remove package index obtained by `apt update`.
 	&& rm -rf /var/lib/apt/lists/*
 
+ENV RIDE2GO_TOKEN=''
+
 EXPOSE 8000
 
 COPY requirements.txt /app/requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@ RUN \
 	# Remove package index obtained by `apt update`.
 	&& rm -rf /var/lib/apt/lists/*
 
+EXPOSE 8000
+
 COPY requirements.txt /app/requirements.txt
 RUN pip install --no-cache-dir --upgrade -r /app/requirements.txt
 
@@ -23,3 +25,5 @@ COPY config /app
 COPY logging.conf /app
 COPY prestart.sh /app
 COPY enhancer.py /app
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ COPY requirements.txt /app/requirements.txt
 RUN pip install --no-cache-dir --upgrade -r /app/requirements.txt
 
 COPY ./app /app/app
+COPY ./static /app/static
 COPY config /app
 COPY logging.conf /app
 COPY prestart.sh /app

--- a/app/services/importing/ride2go.py
+++ b/app/services/importing/ride2go.py
@@ -35,7 +35,7 @@ def import_ride2go() -> List[Carpool]:
 
     ride2go_url = "https://ride2go.com/api/v1/trips/export"
 
-    api_key = secrets.secrets.get('ride2go')
+    api_key = secrets.ride2go_token
 
     ride2go_headers = {
         'Content-type': 'text/plain;charset=UTF-8',

--- a/app/services/secrets.py
+++ b/app/services/secrets.py
@@ -3,7 +3,7 @@ from pydantic import BaseSettings, Field
 
 # Example: secrets = { "mfdz": "some secret" }
 class Secrets(BaseSettings):
-    secrets: Dict[str, str] = Field({})
+    ride2go_token: str = Field(None, env = 'RIDE2GO_TOKEN')
 
 
 # Read if file exists, otherwise no error (it's in .gitignore)


### PR DESCRIPTION
This is an inaccidental follow-up PR of #3. It adds the remaining changes that are necessary so that we can use Amarillo in production at the bbnavi project.

- @frankgerhardt Please have a look at afa3d9c, if it looks & works as you want it to.
- I have re-added the `CMD` line and the `static` directory, they were missing in `Dockerfile`.