### PR TITLE
Remove env from enhancer, agencies from config

### DIFF
--- a/app/configuration.py
+++ b/app/configuration.py
@@ -60,9 +60,10 @@ def configure_enhancer_services():
         {"url": "https://data.mfdz.de/mfdz/stops/parkings_osm.csv", "vicinity": 500}
     ]
     stop_store = stops.StopsStore()
-    if config.env == 'PROD':
-        for stops_source in stop_sources:
-            stop_store.register_stops(stops_source["url"], stops_source["vicinity"])
+
+    for stops_source in stop_sources:
+        stop_store.register_stops(stops_source["url"], stops_source["vicinity"])
+
     container['stops_store'] = stop_store
     container['trips_store'] = trips.TripStore(stop_store)
     container['carpools'] = CarpoolService(container['trips_store'])
@@ -81,10 +82,8 @@ def configure_enhancer_services():
                 container['carpools'].delete(carpool.agency, carpool.id)
 
     logger.info("Restored carpools: %s", container['carpools'].get_all_ids())
-
-    if config.env == 'PROD':
-        logger.info("Starting scheduler")
-        gtfs_generator.start_schedule()
+    logger.info("Starting scheduler")
+    gtfs_generator.start_schedule()
 
 
 def configure_admin_token():

--- a/app/services/config.py
+++ b/app/services/config.py
@@ -4,7 +4,6 @@ from typing import List
 
 class Config(BaseSettings):
     admin_token: str = None
-    agencies: List[str] = []
     ride2go_query_data: str
     env: str = 'DEV'
 

--- a/config
+++ b/config
@@ -1,5 +1,3 @@
-agencies = [ "mfdz", "ride2go", "mifaz", "bessermitfahren"]
-
 # Brandenburg
 ride2go_query_data = '{ "southWestCoordinates": { "lat": 51.083, "lon": 10.657 }, "northEastCoordinates": { "lat": 53.593, "lon": 14.788 }, "lastModifiedSinceDays": 180 }'
 env = 'PROD'


### PR DESCRIPTION
This PR removes env check from enhancer. As env==PROD is checked for publishing agencyconf endpoints, it is still required in config.

However, the `agencies: List[str]` is not required any longer, as agencies are explicitly modeled.