### PR TITLE
Add datahub as stop source

### DIFF
--- a/app/configuration.py
+++ b/app/configuration.py
@@ -55,9 +55,9 @@ def configure_enhancer_services():
 
     logger.info("Load stops...")
     stop_sources = [
-        {"url": "https://data.mfdz.de/mfdz/stops/custom.csv", "vicinity": 50},
+        {"url": "https://datahub.bbnavi.de/export/rideshare_points.geojson", "vicinity": 50},
         {"url": "https://data.mfdz.de/mfdz/stops/stops_zhv.csv", "vicinity": 50},
-        {"url": "https://data.mfdz.de/mfdz/stops/parkings_osm.csv", "vicinity": 500}
+        {"url": "https://data.mfdz.de/mfdz/stops/parkings_osm.csv", "vicinity": 500},      
     ]
     stop_store = stops.StopsStore()
 

--- a/app/models/Carpool.py
+++ b/app/models/Carpool.py
@@ -31,7 +31,7 @@ class StopTime(BaseModel):
                     "the DHID which is available via the 'zentrales "
                     "Haltestellenverzeichnis (zHV)', published by DELFI e.V. "
                     "Note, that currently carpooling location.",
-        regex=r"^([a-zA-Z]{2,5}):\d+:\d+(:\d*(:\w+)?)?$|^osm:[nwr]\d+$",
+        regex=r"^([a-zA-Z]{2,6}):\d+:\d+(:\d*(:\w+)?)?$|^osm:[nwr]\d+$",
         example="de:12073:900340137::2")
 
     name: str = Field(

--- a/app/services/gtfs_export.py
+++ b/app/services/gtfs_export.py
@@ -8,6 +8,7 @@ import logging
 import re
 from app.utils.utils import assert_folder_exists
 from app.models.gtfs import GtfsTimeDelta, GtfsFeedInfo, GtfsAgency, GtfsRoute, GtfsStop, GtfsStopTime, GtfsTrip, GtfsCalendar, GtfsCalendarDate, GtfsShape
+from app.services.stops import is_carpooling_stop
 
 logger = logging.getLogger(__name__)
 
@@ -192,10 +193,8 @@ class GtfsExport:
             return (self.bbox[0] <= stop.stop_lon <= self.bbox[2] and 
                 self.bbox[1] <= stop.stop_lat <= self.bbox[3])
         else:
-            stop_name = stop.stop_name.lower() 
-            # mfdz: prefixed stops are custom stops which are explicitly meant to be carpooling stops
-            return stop.stop_id.startswith('mfdz:') or 'mitfahr' in stop_name or 'p&m' in stop_name 
-        
+            return is_carpooling_stop(stop.stop_id, stop.stop_name)
+            
     def _load_stored_stop(self, stop):
         gtfsstop = self._convert_stop(stop)
         stop_hash = self._stop_hash(stop)

--- a/app/services/trips.py
+++ b/app/services/trips.py
@@ -1,6 +1,7 @@
 from app.models.gtfs import GtfsTimeDelta, GtfsStopTime
 from app.models.Carpool import Carpool, Weekday, StopTime, PickupDropoffType
 from app.services.routing import RoutingService
+from app.services.stops import is_carpooling_stop
 from app.utils.utils import assert_folder_exists
 from shapely.geometry import Point, box
 from geojson_pydantic.geometries import LineString
@@ -290,7 +291,7 @@ class TripTransformer:
                     logger.debug("Skipped stop %s", current_stop.id)
                     continue
             else:
-                if (current_stop.time-stops_frame.iloc[i-1].time) < 5000 and not i==1:
+                if (current_stop.time-stops_frame.iloc[i-1].time) < 5000 and not i==1 and not is_carpooling_stop(current_stop.id, current_stop.stop_name):
                     # skip latter stop if it's very close (<5 seconds drive) by the preceding
                     logger.debug("Skipped stop %s", current_stop.id)
                     continue

--- a/app/tests/test_gtfs.py
+++ b/app/tests/test_gtfs.py
@@ -1,5 +1,3 @@
-from fastapi.testclient import TestClient
-from app.main import app, configure_services
 from app.tests.sampledata import carpool_1234, data1, carpool_repeating_json
 from app.services.gtfs_export import GtfsExport
 from app.services.gtfs import GtfsRtProducer
@@ -10,7 +8,6 @@ from datetime import datetime
 import time
 import pytest
 
-client = TestClient(app)
 
 def test_gtfs_generation():
     cp = Carpool(**data1)

--- a/app/tests/test_stops_store.py
+++ b/app/tests/test_stops_store.py
@@ -3,8 +3,14 @@ from app.services import stops
 def test_load_stops_from_file():
     store = stops.StopsStore()
     store.register_stops("app/tests/stops.csv")
+    assert len(store.stopsDataFrames[0]['stops']) > 0
 
-def test_load_stops_from_web_():
+def test_load_csv_stops_from_web_():
     store = stops.StopsStore()
     store.register_stops("https://data.mfdz.de/mfdz/stops/custom.csv")
+    assert len(store.stopsDataFrames[0]['stops']) > 0
     
+def test_load_geojson_stops_from_web_():
+    store = stops.StopsStore()
+    store.register_stops("https://datahub.bbnavi.de/export/rideshare_points.geojson")
+    assert len(store.stopsDataFrames[0]['stops']) > 0


### PR DESCRIPTION
The bbnavi datahub provides an editor for municipalities to create carpooling stops.

This PR loads these from a geojson endpoint and handles them as carpooling stops. As carpooling stops, they have high priority and are exported to GTFS, even if there is a public transit stop nearby.