### PR TITLE
Add config parameter max_age_carpool_offers_in_days

### DIFF
--- a/amarillo/services/carpools.py
+++ b/amarillo/services/carpools.py
@@ -3,16 +3,16 @@ import logging
 from datetime import datetime
 from typing import Dict
 from amarillo.models.Carpool import Carpool
+from amarillo.services.config import config
 from amarillo.services.trips import TripStore
 from amarillo.utils.utils import yesterday, is_older_than_days
 
 logger = logging.getLogger(__name__)
 
 class CarpoolService():
-    MAX_OFFER_AGE_IN_DAYS = 180
-
-    def __init__(self, trip_store):
-
+    
+    def __init__(self, trip_store, max_age_carpool_offers_in_days: int = 180):
+        self.max_age_carpool_offers_in_days = max_age_carpool_offers_in_days
         self.trip_store = trip_store
         self.carpools: Dict[str, Carpool] = {}
 
@@ -22,10 +22,10 @@ class CarpoolService():
             * it's completly in the past (if it's a single date offer).
               As we know the start time but not latest arrival, we deem
               offers starting the day before yesterday as outdated
-            * it's last update occured before MAX_OFFER_AGE_IN_DAYS
+            * it's last update occured before self.max_age_carpool_offers_in_days
         """
         runs_once = not isinstance(carpool.departureDate, set)        
-        return (is_older_than_days(carpool.lastUpdated.date(), self.MAX_OFFER_AGE_IN_DAYS) or
+        return (is_older_than_days(carpool.lastUpdated.date(), self.max_age_carpool_offers_in_days) or
             (runs_once and carpool.departureDate < yesterday()))
 
     def purge_outdated_offers(self):

--- a/amarillo/services/config.py
+++ b/amarillo/services/config.py
@@ -9,5 +9,6 @@ class Config(BaseSettings):
     env: str = 'DEV'
     graphhopper_base_url: str = 'https://api.mfdz.de/gh'
     stop_sources_file: str = 'conf/stop_sources.json'
+    max_age_carpool_offers_in_days: int = 180
 
 config = Config(_env_file='config', _env_file_encoding='utf-8')


### PR DESCRIPTION
This PR adds a config parameter `max_age_carpool_offers_in_days` to configure the maximum age of carpool offers before they are not included in amarillo's feeds any longer.

The default setting is 180 days (~ half a year). It can be overriden be defining e.g. 

`max_age_carpool_offers_in_days=3640` in amarillo's config.
