### PR TITLE
Call enhancer, carpool events

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,5 +35,9 @@ COPY ./amarillo/static/config /app
 COPY ./amarillo/static/logging.conf /app
 COPY ./amarillo/static/data /app/data
 
+# Create the error.log, otherwise we get a permission error when we try to write to it
+RUN touch /app/error.log
+RUN chmod 777 /app/error.log
+
 # This image inherits uvicorn-gunicorn's CMD. If you'd like to start uvicorn, use this instead
 # CMD ["uvicorn", "amarillo.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,15 +18,11 @@ RUN \
  ENV ADMIN_TOKEN=''
  ENV RIDE2GO_TOKEN=''
  ENV SECRET_KEY=''
- ENV METRICS_USER=''
- ENV METRICS_PASSWORD=''
 
 EXPOSE 80
 
-ARG PLUGINS
-
 COPY requirements.txt /app/requirements.txt
-RUN pip install --no-cache-dir --upgrade -r /app/requirements.txt ${PLUGINS}
+RUN pip install --no-cache-dir --upgrade -r /app/requirements.txt
 
 # set MODULE_NAME explicitly
 ENV MODULE_NAME=amarillo.main

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,17 +1,17 @@
 pipeline {
-    agent any
+    agent { label 'builtin' }
     environment {
         GITEA_CREDS = credentials('AMARILLO-JENKINS-GITEA-USER')
-        PYPI_CREDS = credentials('AMARILLO-JENKINS-PYPI-USER')
         TWINE_REPO_URL = "https://git.gerhardt.io/api/packages/amarillo/pypi"
         PLUGINS_REPO_URL = "git.gerhardt.io/api/packages/amarillo/pypi/simple"
-        DOCKER_REGISTRY_URL = 'https://git.gerhardt.io'
+        DOCKER_REGISTRY = 'git.gerhardt.io'
+        DERIVED_DOCKERFILE = 'standard.Dockerfile'
         OWNER = 'amarillo'
+        BASE_IMAGE_NAME = 'amarillo-base'
         IMAGE_NAME = 'amarillo'
-        AMARILLO_DISTRIBUTION = '0.1'
-        TAG = "${AMARILLO_DISTRIBUTION}.${BUILD_NUMBER}"
-        PLUGINS = 'amarillo-metrics amarillo-enhancer amarillo-grfs-export'
-        DEPLOY_WEBHOOK_URL = 'http://amarillo.mfdz.de:8888/mitanand'
+        AMARILLO_DISTRIBUTION = '0.3'
+        TAG = "${AMARILLO_DISTRIBUTION}.${BUILD_NUMBER}${env.BRANCH_NAME == 'main' ? '' : '-' + env.BRANCH_NAME}"
+        DEPLOY_WEBHOOK_URL = "http://amarillo.mfdz.de:8888/${env.BRANCH_NAME}" 
         DEPLOY_SECRET = credentials('AMARILLO-JENKINS-DEPLOY-SECRET')
     }
     stages {
@@ -42,35 +42,56 @@ pipeline {
                 sh 'python3 -m twine upload --skip-existing --verbose --repository-url $TWINE_REPO_URL --username $GITEA_CREDS_USR --password $GITEA_CREDS_PSW ./dist/*'              
             }
         }
-        stage('Publish package to PyPI') {
+        stage('Build base docker image') {
             when {
-                branch 'release'
-            }
-            steps {
-                sh 'python3 -m twine upload --verbose --username $PYPI_CREDS_USR --password $PYPI_CREDS_PSW ./dist/*'              
-            }
-        }
-        stage('Build Mitanand docker image') {
-            when {
-                branch 'mitanand'
+                isDeployBranch()
             }
             steps {
                 echo 'Building image'
                 script {
-                    docker.build("${OWNER}/${IMAGE_NAME}:${TAG}",
-                    //--no-cache to make sure plugins are updated
-                     "--no-cache --build-arg='PACKAGE_REGISTRY_URL=${PLUGINS_REPO_URL}' --build-arg='PLUGINS=${PLUGINS}' --secret id=AMARILLO_REGISTRY_CREDENTIALS,env=GITEA_CREDS .")
+                    docker.build("${OWNER}/${BASE_IMAGE_NAME}:${TAG}")
                 }
             }
         }
-        stage('Push image to container registry') {
+        stage('Push base image to container registry') {
             when {
-                branch 'mitanand'
+                isDeployBranch()
             }
             steps {
                 echo 'Pushing image to registry'
                 script {
-                    docker.withRegistry(DOCKER_REGISTRY_URL, 'AMARILLO-JENKINS-GITEA-USER'){
+                    docker.withRegistry("https://${DOCKER_REGISTRY}", 'AMARILLO-JENKINS-GITEA-USER'){
+                        def image = docker.image("${OWNER}/${BASE_IMAGE_NAME}:${TAG}")
+                        image.push()
+                        image.push('latest')
+                    }
+                }
+            }
+        }
+        stage('Build derived docker image') {
+            when {
+                isDeployBranch()
+            }
+            steps {
+                echo 'Building image'
+                script {
+                    docker.withRegistry("https://${DOCKER_REGISTRY}", 'AMARILLO-JENKINS-GITEA-USER'){
+                        docker.build("${OWNER}/${IMAGE_NAME}:${TAG}",
+                        //--no-cache to make sure plugins are updated
+                        "-f ${DERIVED_DOCKERFILE} --no-cache --build-arg='PACKAGE_REGISTRY_URL=${PLUGINS_REPO_URL}' --build-arg='DOCKER_REGISTRY=${DOCKER_REGISTRY}' --secret id=AMARILLO_REGISTRY_CREDENTIALS,env=GITEA_CREDS .")
+                    }
+
+                }
+            }
+        }
+        stage('Push derived image to container registry') {
+            when {
+                isDeployBranch()
+            }
+            steps {
+                echo 'Pushing image to registry'
+                script {
+                    docker.withRegistry("https://${DOCKER_REGISTRY}", 'AMARILLO-JENKINS-GITEA-USER'){
                         def image = docker.image("${OWNER}/${IMAGE_NAME}:${TAG}")
                         image.push()
                         image.push('latest')
@@ -80,7 +101,7 @@ pipeline {
         }
         stage('Notify CD script') {
             when {
-                branch 'mitanand'
+                isDeployBranch()
             }
             steps {
                 echo 'Triggering deploy webhook'
@@ -92,4 +113,8 @@ pipeline {
             }
         }
     }
+}
+
+def isDeployBranch() {
+    return anyOf { branch 'main'; branch 'dev'; branch 'mitanand' }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ pipeline {
         DOCKER_REGISTRY_URL = 'https://git.gerhardt.io'
         OWNER = 'amarillo'
         IMAGE_NAME = 'amarillo'
-        AMARILLO_DISTRIBUTION = '0.2'
+        AMARILLO_DISTRIBUTION = '0.1'
         TAG = "${AMARILLO_DISTRIBUTION}.${BUILD_NUMBER}"
         PLUGINS = 'amarillo-metrics amarillo-enhancer amarillo-grfs-export'
         DEPLOY_WEBHOOK_URL = 'http://amarillo.mfdz.de:8888/mitanand'

--- a/amarillo/routers/carpool.py
+++ b/amarillo/routers/carpool.py
@@ -13,7 +13,7 @@ from amarillo.models.Carpool import Carpool
 from amarillo.models.User import User
 from amarillo.services.oauth2 import get_current_user, verify_permission
 from amarillo.tests.sampledata import examples
-
+from amarillo.services.hooks import run_on_create, run_on_delete
 from amarillo.services.config import config
 from amarillo.utils.utils import assert_folder_exists
 
@@ -52,6 +52,8 @@ def enhance_trip(carpool: Carpool):
 async def post_carpool(background_tasks: BackgroundTasks, carpool: Carpool = Body(..., examples=examples),
                        requesting_user: User = Depends(get_current_user)) -> Carpool:
     verify_permission(f"{carpool.agency}:write", requesting_user)
+
+    background_tasks.add_task(run_on_create, carpool)
 
     logger.info(f"POST trip {carpool.agency}:{carpool.id}.")
     await assert_agency_exists(carpool.agency)
@@ -94,12 +96,14 @@ async def get_carpool(agency_id: str, carpool_id: str, requesting_user: User = D
                        "description": "Carpool or agency not found"},
                },
                )
-async def delete_carpool(agency_id: str, carpool_id: str, requesting_user: User = Depends(get_current_user)):
+async def delete_carpool(background_tasks: BackgroundTasks, agency_id: str, carpool_id: str, requesting_user: User = Depends(get_current_user)):
     verify_permission(f"{agency_id}:write", requesting_user)
 
     logger.info(f"Delete trip {agency_id}:{carpool_id}.")
     await assert_agency_exists(agency_id)
     await assert_carpool_exists(agency_id, carpool_id)
+    cp = await load_carpool(agency_id, carpool_id)
+    background_tasks.add_task(run_on_delete, cp)
     
     return await _delete_carpool(agency_id, carpool_id)
 
@@ -115,12 +119,6 @@ async def _delete_carpool(agency_id: str, carpool_id: str):
         os.remove(f"data/enhanced/{agency_id}/{carpool_id}.json", )
     except FileNotFoundError:
         pass
-
-    try:
-        from amarillo.plugins.metrics import trips_deleted_counter
-        trips_deleted_counter.inc()
-    except ImportError:
-        pass
     
 
 async def store_carpool(carpool: Carpool) -> Carpool:
@@ -128,17 +126,6 @@ async def store_carpool(carpool: Carpool) -> Carpool:
 
     await set_lastUpdated_if_unset(carpool)
     await save_carpool(carpool)
-
-    try:
-        from amarillo.plugins.metrics import trips_created_counter, trips_updated_counter
-        if(carpool_exists):
-            # logger.info("Incrementing trips updated")
-            trips_updated_counter.inc()
-        else:
-            # logger.info("Incrementing trips created")
-            trips_created_counter.inc()
-    except ImportError:
-        pass
 
     return carpool
 
@@ -180,4 +167,6 @@ async def delete_agency_carpools_older_than(agency_id, timestamp):
         if os.path.getmtime(carpool_file_name) < timestamp:
             m = re.search(r'([a-zA-Z0-9_-]+)\.json$', carpool_file_name)
             # TODO log deletion
+            cp = await load_carpool(agency_id, m[1])
+            run_on_delete(cp)
             await _delete_carpool(agency_id, m[1])

--- a/amarillo/services/carpools.py
+++ b/amarillo/services/carpools.py
@@ -37,11 +37,6 @@ class CarpoolService():
             if cp and self.is_outdated(cp):
                 logger.info("Purge outdated offer %s", key)
                 self.delete(cp.agency, cp.id)
-                try:
-                    from amarillo.plugins.metrics import trips_deleted_counter
-                    trips_deleted_counter.inc()
-                except ImportError:
-                    pass
 
     def get(self, agency_id: str, carpool_id: str):
         return self.carpools.get(f"{agency_id}:{carpool_id}")

--- a/amarillo/services/config.py
+++ b/amarillo/services/config.py
@@ -9,5 +9,6 @@ class Config(BaseSettings):
     env: str = 'DEV'
     graphhopper_base_url: str = 'https://api.mfdz.de/gh'
     stop_sources_file: str = 'data/stop_sources.json'
+    enhancer_url: str = 'http://localhost:8001'
 
 config = Config(_env_file='config', _env_file_encoding='utf-8')

--- a/amarillo/services/hooks.py
+++ b/amarillo/services/hooks.py
@@ -1,0 +1,27 @@
+from typing import List
+from amarillo.models.Carpool import Carpool
+
+class CarpoolEvents:
+    def on_create(cp : Carpool):
+        pass
+    def on_update(cp : Carpool):
+        pass
+    def on_delete(cp : Carpool):
+        pass
+
+carpool_event_listeners : List[CarpoolEvents] = []
+
+def register_carpool_event_listener(cpe : CarpoolEvents):
+    carpool_event_listeners.append(cpe)
+
+def run_on_create(cp: Carpool):
+    for cpe in carpool_event_listeners:
+        cpe.on_create(cp)
+
+def run_on_update(cp: Carpool):
+    for cpe in carpool_event_listeners:
+        cpe.on_update(cp)
+
+def run_on_delete(cp: Carpool):
+    for cpe in carpool_event_listeners:
+        cpe.on_delete(cp)

--- a/amarillo/services/users.py
+++ b/amarillo/services/users.py
@@ -65,6 +65,7 @@ class UserService:
         logger.error(message)
         raise HTTPException(status_code=400, detail=message)
 
+    #TODO: fix duplicate None api key
     def add(self, user_conf: User):
 
         user_id = user_conf.user_id

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amarillo"
-version = "0.0.15a3"
+version = "0.0.17a1"
 description = "Aggregates and enhances carpooling-offers and publishes them as GTFS(-RT)"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/standard.Dockerfile
+++ b/standard.Dockerfile
@@ -1,0 +1,16 @@
+ARG DOCKER_REGISTRY
+FROM ${DOCKER_REGISTRY}/amarillo/amarillo-base
+
+ARG PLUGINS=\
+"amarillo-metrics "\
+"amarillo-gtfs-exporter "
+
+ARG PACKAGE_REGISTRY_URL
+
+ENV METRICS_USER=''
+ENV METRICS_PASSWORD=''
+
+# RUN pip install $PLUGINS
+
+RUN --mount=type=secret,id=AMARILLO_REGISTRY_CREDENTIALS \
+pip install --no-cache-dir --upgrade --extra-index-url https://$(cat /run/secrets/AMARILLO_REGISTRY_CREDENTIALS)@${PACKAGE_REGISTRY_URL} ${PLUGINS}


### PR DESCRIPTION
Call to enhancer: with the enhancer separated to another FastAPI service, whenever a carpool is changed, a background task is created that calls the enhancer configured in `enhancer_url` and saves the new carpool to data/enhanced.

The Amarillo docker image has been separated into a base and a derived image. The base image only contains Amarillo with no plugins, while the derived image has the plugins included. This way plugins can be more easily interchanged/updated without recreating the entire image, and different deployments can use a different set of plugins with the same underlying base image.

Carpool event hook system: plugins can now register callbacks to be run when a carpool is created/updated/deleted, e.g the metrics plugin uses it to count the number of carpool changes with all of the necessary code encapsulated in the plugin itself. More events can be added later.