### PR TITLE
pin numpy dep to <2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ pyproj==3.6.1
 geojson-pydantic==1.0.1
 watchdog==3.0.0
 idna>=3.7
+numpy==1.26.4


### PR DESCRIPTION
Since numpy 2.x release, dependencies (like pandas) have been broken.
Pinning the numpy version to most recent 1.x release solves this.