### PR TITLE
Feature: support exception dates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,7 +137,15 @@ secrets
 gtfs/*.zip
 gtfs/*.pbf
 gtfs/*.json
-data
+
+# data/agencyconf is explictly not ignored, as needed for tests
+data/carpool/
+data/enhanced/
+data/failed/
+data/trash/
+data/gtfs/
+data/tmp
+
 
 #these files are under app/static but they get copied to the outside directory on startup
 logging.conf

--- a/amarillo/routers/carpool.py
+++ b/amarillo/routers/carpool.py
@@ -110,7 +110,7 @@ async def load_carpool(agency_id, carpool_id) -> Carpool:
 
 async def save_carpool(carpool, folder: str = 'data/carpool'):
     with open(f'{folder}/{carpool.agency}/{carpool.id}.json', 'w', encoding='utf-8') as f:
-        f.write(carpool.json())
+        f.write(carpool.model_dump_json())
 
 
 async def assert_agency_exists(agency_id: str):

--- a/amarillo/services/agencyconf.py
+++ b/amarillo/services/agencyconf.py
@@ -86,7 +86,7 @@ class AgencyConfService:
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=message)
 
         with open(f'{agency_conf_directory}/{agency_id}.json', 'w', encoding='utf-8') as f:
-            f.write(agency_conf.json())
+            f.write(agency_conf.model_dump_json())
 
         self.agency_id_to_agency_conf[agency_id] = agency_conf
         self.api_key_to_agency_id[api_key] = agency_id

--- a/amarillo/services/trips.py
+++ b/amarillo/services/trips.py
@@ -110,7 +110,7 @@ class TripStore():
                     return
                 assert_folder_exists(f'data/enhanced/{carpool.agency}/')
                 with open(filename, 'w', encoding='utf-8') as f:
-                    f.write(enhanced_carpool.json())
+                    f.write(enhanced_carpool.model_dump_json())
                 logger.info("Added enhanced carpool %s:%s", carpool.agency, carpool.id)
             
             return self._load_as_trip(enhanced_carpool)
@@ -124,7 +124,7 @@ class TripStore():
     def handle_failed_carpool_enhancement(sellf, carpool: Carpool):
         assert_folder_exists(f'data/failed/{carpool.agency}/')
         with open(f'data/failed/{carpool.agency}/{carpool.id}.json', 'w', encoding='utf-8') as f:
-            f.write(carpool.json())
+            f.write(carpool.model_dump_json())
 
     def distance_in_m(self, carpool):
         if len(carpool.stops) < 2:

--- a/amarillo/tests/sampledata.py
+++ b/amarillo/tests/sampledata.py
@@ -65,6 +65,20 @@ carpool_repeating_json = {
     'departureDate': ["monday"],
 }
 
+carpool_with_exception_dates = {
+    'id': "carpool_with_exception_dates",
+    'agency': "mfdz",
+    'deeplink': "https://mfdz.de/trip/123",
+    'stops': [
+        {'id': "mfdz:12073:001", 'name': "abc", 'lat': 53.11901, 'lon': 14.015776},
+        {'id': "de:12073:900340137::3", 'name': "xyz", 'lat': 53.011459, 'lon': 13.94945}],
+    'departureTime': "15:00",
+    'departureDate': ["monday"],
+    'exceptionDates': [ 
+        { "date": "2025-01-01", "exceptionType": "removed"},
+        { "date": "2025-01-02", "exceptionType": "added"}
+    ]
+}
 
 cp1 = Carpool(**data1)
 

--- a/amarillo/tests/test_gtfs.py
+++ b/amarillo/tests/test_gtfs.py
@@ -1,4 +1,4 @@
-from amarillo.tests.sampledata import carpool_1234, data1, carpool_repeating_json, stop_issue
+from amarillo.tests.sampledata import carpool_1234, data1, carpool_repeating_json, carpool_with_exception_dates, stop_issue
 from amarillo.services.gtfs_export import GtfsExport
 from amarillo.services.gtfs import GtfsRtProducer
 from amarillo.services.stops import StopsStore
@@ -18,6 +18,18 @@ def test_gtfs_generation():
 
     exporter = GtfsExport(None, None, trips_store, stops_store)
     exporter.export('target/tests/test_gtfs_generation/test.gtfs.zip', "target/tests/test_gtfs_generation")
+
+def test_gtfs_generation_with_exception_dates():
+    cp = Carpool(**carpool_with_exception_dates)
+    stops_store = StopsStore()
+    trips_store = TripStore(stops_store, AgencyConfService())
+    trips_store.put_carpool(cp)
+
+    exporter = GtfsExport(None, None, trips_store, stops_store)
+    exporter._prepare_gtfs_feed(trips_store, stops_store)
+    assert len(exporter.calendar_dates) == 2
+    assert exporter.calendar_dates[0].date == '20250102'
+    assert exporter.calendar_dates[0].exception_type == 1
 
 def test_correct_stops():
     cp = Carpool(**stop_issue)

--- a/data/agencyconf/mfdz.json
+++ b/data/agencyconf/mfdz.json
@@ -1,0 +1,1 @@
+{"agency_id": "mfdz", "api_key": "THISKEYMUSTBECHANGED"}


### PR DESCRIPTION
This PR introduces support for exception dates for repeating trip offers.

These are optional and can be provided as in the following example:
```json
{ 
  "exceptionDates": [
    { "date": "2025-01-01", "exceptionType": "removed" },
    { "date": "2025-01-02", "exceptionType": "added" }
  ]
}
```

These will be exported in GTFS as `calendar_date` entries.  

Note: at most 90 exceptionDates per trip are currently supported. 