### PR TITLE
feat: provide download url via agency conf

### DIFF
--- a/amarillo/configuration.py
+++ b/amarillo/configuration.py
@@ -84,7 +84,7 @@ def configure_enhancer_services():
 
     logger.info("Restored carpools: %s", container['carpools'].get_all_ids())
     logger.info("Starting scheduler")
-    Syncer(FileBasedStore(), container["agencies"]).schedule_full_sync(config.daily_sync_time)
+    Syncer(FileBasedStore(), container["agencyconf"]).schedule_full_sync(config.daily_sync_time)
     gtfs_generator.start_schedule()
 
 

--- a/amarillo/models/AgencyConf.py
+++ b/amarillo/models/AgencyConf.py
@@ -1,5 +1,6 @@
-from pydantic import ConfigDict, BaseModel, Field
+from pydantic import ConfigDict, BaseModel, Field, HttpUrl
 from enum import Enum
+from typing import Optional
 
 
 class AgencyRole(str, Enum):
@@ -21,6 +22,11 @@ class AgencyConf(BaseModel):
         max_length=256,
         pattern=r'^[a-zA-Z0-9]+$',
         examples=["d8yLuY4DqMEUCLcfJASi"])
+
+    offers_download_url: Optional[HttpUrl] = Field(
+        description="The agency's URL to download offers",
+        default=None,
+        examples=["https://mfdz.de/carpools/offers"])
 
     add_dropoffs_and_pickups: bool = Field(
         description="Should Amarillo add pickup/dropoff points along the route?",

--- a/amarillo/services/agencyconf.py
+++ b/amarillo/services/agencyconf.py
@@ -6,7 +6,7 @@ import logging
 
 from fastapi import HTTPException, status
 
-from amarillo.models.AgencyConf import AgencyConf
+from amarillo.models.AgencyConf import AgencyConf, AgencyRole
 from amarillo.services.config import config
 
 logger = logging.getLogger(__name__)
@@ -27,6 +27,11 @@ class AgencyConfService:
                 dictionary = json.load(agency_conf_file)
 
                 agency_conf = AgencyConf(**dictionary)
+
+                # Default: if no role was defined, the default role is
+                # carpool_agency.
+                if agency_conf.roles is None:
+                    agency_conf.roles = [AgencyRole.carpool_agency]
 
                 agency_id = agency_conf.agency_id
                 api_key = agency_conf.api_key
@@ -100,6 +105,9 @@ class AgencyConfService:
 
     def get_agency_ids(self) -> List[str]:
         return list(self.agency_id_to_agency_conf.keys())
+
+    def get_all_agencies(self):
+        return list(self.agency_id_to_agency_conf.values())
 
     def delete(self, agency_id):
 

--- a/amarillo/services/importing/amarillo.py
+++ b/amarillo/services/importing/amarillo.py
@@ -12,7 +12,7 @@ class AmarilloImporter:
 
     def __init__(self, agency_id, url):
         self.agency_id = agency_id
-        self.carpools_url = url
+        self.carpools_url = str(url)
 
     @staticmethod
     def _extract_stop(stop):

--- a/amarillo/services/importing/noi.py
+++ b/amarillo/services/importing/noi.py
@@ -7,7 +7,6 @@ import requests
 
 from amarillo.models.Carpool import Carpool, StopTime
 from amarillo.services.config import config
-from amarillo.services.secrets import secrets
 
 logger = logging.getLogger(__name__)
 

--- a/amarillo/services/secrets.py
+++ b/amarillo/services/secrets.py
@@ -5,10 +5,6 @@ from pydantic_settings import BaseSettings
 # Example: secrets = { "mfdz": "some secret" }
 class Secrets(BaseSettings):
     ride2go_token: str = Field(None)
-    bessermitfahren_url: Optional[str] = Field(None)
-    pendlerportal_url: Optional[str] = Field(None)
-    mycarpoolapp_url: Optional[str] = Field(None)
-
     # TODO: admin_token should be moved here instead of config
 
 

--- a/amarillo/services/sync.py
+++ b/amarillo/services/sync.py
@@ -4,50 +4,52 @@ import time
 
 import schedule
 
+from amarillo.models.AgencyConf import AgencyConf, AgencyRole
 from amarillo.services.importing import (
+    AmarilloImporter,
     BessermitfahrenImporter,
     MyCarpoolAppImporter,
     NoiImporter,
     PendlerportalImporter,
     Ride2GoImporter,
 )
-from amarillo.services.secrets import secrets
 
 logger = logging.getLogger(__name__)
 
 
 class Syncer:
-    def __init__(self, store, agency_service):
+    def __init__(self, store, agencyconf_service):
         self.store = store
-        self.agency_service = agency_service
+        self.agencyconf_service = agencyconf_service
 
-    def perform_full_sync(self):
-        agencies = self.agency_service.get_all_agencies()
-        for agency_id in agencies:
+    def perform_full_sync(self) -> None:
+        agencies = self.agencyconf_service.get_all_agencies()
+        for agency in [agency for agency in agencies if self.should_sync(agency)]:
             try:
-                asyncio.run(self.sync(agency_id))
+                asyncio.run(self.sync(agency.agency_id, agency.offers_download_url))
             except Exception as e:
-                logger.exception(f"Could not import {agency_id}: {e}")
+                logger.exception(f"Could not import {agency.agency_id}: {e}")
+
+    def should_sync(self, agency: AgencyConf) -> bool:
+        return agency.offers_download_url is not None and AgencyRole.carpool_agency in agency.roles
 
     def schedule_full_sync(self, time_str):
         schedule.every().day.at(time_str).do(self.perform_full_sync)
 
-    async def sync(self, agency_id):
+    async def sync(self, agency_id: str, offers_download_url = None):
         if agency_id == "ride2go":
             importer = Ride2GoImporter()
         elif agency_id == "ummadum":
             importer = NoiImporter(agency_id, test_mode=True)
         elif agency_id == "bessermitfahren":
-            importer = BessermitfahrenImporter(secrets.bessermitfahren_url)
+            importer = BessermitfahrenImporter(offers_download_url)
         elif agency_id == "pendlerportal":
-            importer = PendlerportalImporter(secrets.pendlerportal_url)
+            importer = PendlerportalImporter(offers_download_url)
         elif agency_id == "mycarpoolapp":
-            importer = MyCarpoolAppImporter(secrets.mycarpoolapp_url)
+            importer = MyCarpoolAppImporter(offers_download_url)
         else:
-            logger.warn(f"Agency {agency_id} does not exist")
-            return None
-            # raise ValueError(f"Agency {agency_id} does not exist.")
-
+            importer = AmarilloImporter(agency_id, offers_download_url)
+        
         sync_start_time = time.time()
         carpools = importer.load_carpools()
         


### PR DESCRIPTION
This PR moves configuration of download urls from secrets to agencyconf.

In consequence, new agencies which support a standard Amarillo download api can be added via config only.