### PR TITLE
Fix: minor fixes

### DIFF
--- a/amarillo/models/gtfs.py
+++ b/amarillo/models/gtfs.py
@@ -38,7 +38,7 @@ def _weekday_sequence(start, end):
     if end - start == 1:
         return f"{WEEKDAYS[start % 7]}, {WEEKDAYS[end % 7]}"
     elif end - start > 1:
-        return f"{WEEKDAYS[start % 7]}-{WEEKDAYS[end % 7]}"
+        return f"{WEEKDAYS[start % 7]} – {WEEKDAYS[end % 7]}"
     return WEEKDAYS[start % 7]
 
 

--- a/amarillo/routers/carpool.py
+++ b/amarillo/routers/carpool.py
@@ -26,8 +26,20 @@ store = FileBasedStore()
 
 examples = [
     {
+        "id": "1234",
+        "agency": "mfdz",
+        "deeplink": "http://mfdz.de",
+        "stops": [
+            {"id": "de:12073:900340137::2", "name": "ABC", "lat": 45, "lon": 9},
+            {"id": "de:12073:900340137::3", "name": "XYZ", "lat": 45, "lon": 9},
+        ],
+        "departureTime": "12:34",
+        "departureDate": "2022-03-30",
+        "lastUpdated": "2022-03-30T12:34:00+00:00",
+    },
+    {
         "id": "1235",
-        "agency_id": "mfdz",
+        "agency": "mfdz",
         "deeplink": "http://mfdz.de",
         "stops": [
             {
@@ -49,18 +61,6 @@ examples = [
         "departureDate": "2025-03-30",
         "lastUpdated": "2025-03-03T18:22:00+00:00",
         "path": {"type": "LineString", "coordinates": [[48.51391, 9.0573], [48.64632, 9.23224], [48.746419, 9.163373]]},
-    },
-    {
-        "id": "1234",
-        "agency_id": "mfdz",
-        "deeplink": "http://mfdz.de",
-        "stops": [
-            {"id": "de:12073:900340137::2", "name": "ABC", "lat": 45, "lon": 9},
-            {"id": "de:12073:900340137::3", "name": "XYZ", "lat": 45, "lon": 9},
-        ],
-        "departureTime": "12:34",
-        "departureDate": "2022-03-30",
-        "lastUpdated": "2022-03-30T12:34:00+00:00",
     },
 ]
 

--- a/amarillo/routers/carpool.py
+++ b/amarillo/routers/carpool.py
@@ -132,10 +132,10 @@ async def set_lastUpdated_if_unset(carpool):
 
 
 async def _assert_agency_exists(agency_id: str):
-    if not store.does_agency_exist(agency_id):
+    if not await store.does_agency_exist(agency_id):
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Agency with id {agency_id} does not exist.")
 
 
 async def _assert_carpool_exists(agency_id: str, carpool_id: str):
-    if not store.does_carpool_exist(agency_id, carpool_id):
+    if not await store.does_carpool_exist(agency_id, carpool_id):
         raise HTTPException(status_code=404, detail=f"Carpool with id {carpool_id} for agency {agency_id} not found")

--- a/amarillo/services/config.py
+++ b/amarillo/services/config.py
@@ -4,7 +4,7 @@ from pydantic_settings import BaseSettings
 
 class Config(BaseSettings):
     amarillo_baseurl: str = 'http://localhost:8000/'
-    admin_token: str
+    admin_token: str | None = None
     ride2go_query_data: str
     env: str = 'DEV'
     graphhopper_base_url: str = 'https://api.mfdz.de/gh'

--- a/amarillo/services/importing/mycarpoolapp.py
+++ b/amarillo/services/importing/mycarpoolapp.py
@@ -6,4 +6,4 @@ class MyCarpoolAppImporter(AmarilloImporter):
         super().__init__("mycarpoolapp", url)
 
     def _get_data_from_json_response(self, json_response):
-        return json_response.get("data")
+        return [cp for cp in json_response.get("data") if not cp.get('isTest') == 1]


### PR DESCRIPTION
This PR includes couple of fixes:

* in the schedule description, minus is replaced by en-dash
* a typo in the api sample carpool offers is fixed (`agency_id` is changed to `agency`)
* missing `await`s are added
* `MaCarpoolApp` offers are ignored, if the have `"isTest": 1` set
* the config param `admin_token` is changed to optional, as not needed for `enhancer.py`