### PR TITLE
fix: override given path if dropoff or pickup stops should be added

### DIFF
--- a/amarillo/models/Carpool.py
+++ b/amarillo/models/Carpool.py
@@ -272,7 +272,7 @@ class Carpool(BaseModel):
             {"date": "2025-01-02", "exceptionType": "added"}])
 
     path: Optional[LineString] = Field(
-        None, description="Optional route geometry as json LineString.")
+        None, description="Optional route geometry as json LineString. Note: this path will only be used, if the agency is configured to NOT enhance intermediate stops. Otherwise, the path will be re-calculated and overridden.")
 
     lastUpdated: Optional[datetime] = Field(
         None,


### PR DESCRIPTION
This PR allows to submit offers with a path property. However, they will be discarded and overridden in case in between pickup/dropoff stops should be calculated for this agency, as, to derive arrival times at stops, a routing is necessary.

In a later version, a subset of waypoints of the provided path might be used as viapoints so the newly calcualted routes will  match the intended one.