### PR TITLE
feat: add debug mode for post requests

### DIFF
--- a/amarillo/main.py
+++ b/amarillo/main.py
@@ -12,7 +12,7 @@ import mimetypes
 from starlette.staticfiles import StaticFiles
 
 from amarillo.routers import carpool, agency, agencyconf, region
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 
 # https://pydantic-docs.helpmanual.io/usage/settings/
 from amarillo.views import home
@@ -62,6 +62,14 @@ def configure():
     configure_services()
     configure_routing()
 
+
+@app.middleware("http")
+async def log_request_data(request: Request, call_next):
+    if request.method == "POST" and config.debug:
+        body = await request.body()
+        logger.info(f"POST Request to {request.url.path} with body: {body.decode('utf-8')}")
+    
+    return await call_next(request)
 
 def configure_routing():
     mimetypes.add_type('application/x-protobuf', '.pbf')

--- a/amarillo/services/config.py
+++ b/amarillo/services/config.py
@@ -5,6 +5,7 @@ from pydantic_settings import BaseSettings
 class Config(BaseSettings):
     amarillo_baseurl: str = 'http://localhost:8000/'
     admin_token: str | None = None
+    debug: bool = False
     ride2go_query_data: str
     env: str = 'DEV'
     graphhopper_base_url: str = 'https://api.mfdz.de/gh'

--- a/config
+++ b/config
@@ -3,3 +3,6 @@ ride2go_query_data = '{ "southWestCoordinates": { "lat": 47.3, "lon": 5.98 }, "n
 env = 'PROD'
 graphhopper_base_url = 'https://api.mfdz.de/gh'
 stop_sources_file = 'conf/stop_sources.json'
+# When debug is set to True, post requests are logged at loglevel INFO. 
+# (Only use this temporarilly to e.g. debug 422 Unprocessable Entity requests)
+debug=False


### PR DESCRIPTION
This PR adds an optional config flag `debug` which allows to log post request bodies, i.e. to analyse wrongly sent carpool offers.