### PR TITLE
Patch incomplete ride2go lastupdated

### DIFF
--- a/amarillo/services/importing/ride2go.py
+++ b/amarillo/services/importing/ride2go.py
@@ -30,6 +30,7 @@ class Ride2GoImporter:
     def _extract_carpool(dict) -> Carpool:
         (agency, id) = re.findall(r'https?://(.*)\..*/?trip=([0-9]+)', dict['deeplink'])[0]
 
+        lastUpdated = dict.get('lastUpdated')
         carpool = Carpool(
             id=id,
             agency=agency,
@@ -37,7 +38,7 @@ class Ride2GoImporter:
             stops=[Ride2GoImporter._extract_stop(s) for s in dict.get('stops')],
             departureTime=dict.get('departTime'),
             departureDate=dict.get('departDate') if dict.get('departDate') else dict.get('weekdays'),
-            lastUpdated=dict.get('lastUpdated'),
+            lastUpdated=lastUpdated +'T00:00:00' if lastUpdated and len(lastUpdated) == 10 else lastUpdated
         )
 
         return carpool

--- a/amarillo/services/importing/ride2go.py
+++ b/amarillo/services/importing/ride2go.py
@@ -12,6 +12,11 @@ logger = logging.getLogger(__name__)
 
 
 class Ride2GoImporter:
+
+    def __init__(self, url, http_headers: dict[str, str] = {}):
+        self.carpools_url = str(url)
+        self.carpools_http_headers = http_headers
+
     @staticmethod
     def _extract_stop(stop):
         return StopTime(
@@ -39,15 +44,8 @@ class Ride2GoImporter:
 
     def load_carpools(self) -> List[Carpool]:
         ride2go_query_data = config.ride2go_query_data
-
-        ride2go_url = 'https://ride2go.com/api/v1/trips/export'
-
-        api_key = secrets.ride2go_token
-
-        ride2go_headers = {'Content-type': 'text/plain;charset=UTF-8', 'X-API-Key': f'{api_key}'}
-
         try:
-            result = requests.get(ride2go_url, data=ride2go_query_data, headers=ride2go_headers)
+            result = requests.get(self.carpools_url, data=ride2go_query_data, headers=self.carpools_http_headers)
             if result.status_code == 200:
                 json_results = result.json()
                 carpools = [self._extract_carpool(cp) for cp in json_results]

--- a/amarillo/services/sync.py
+++ b/amarillo/services/sync.py
@@ -39,7 +39,7 @@ class Syncer:
 
     async def sync(self, agency_id: str, offers_download_url=None, offers_download_http_headers=None):
         if agency_id == "ride2go":
-            importer = Ride2GoImporter()
+            importer = Ride2GoImporter(offers_download_url, offers_download_http_headers)
         elif agency_id == "ummadum":
             importer = NoiImporter(agency_id, test_mode=True)
         elif agency_id == "bessermitfahren":


### PR DESCRIPTION
Ride2Go started sending `lastUpdated` timestamps with date only values. This patch appends `T00:00:00` in case only date is provided.

Besides this, this PR switches from custom url/http headers provision to the now used style providing these via agencyconf.